### PR TITLE
fix: nyaasi returns 404 for a new release

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,3 @@
 export const NYAASI_RSS = 'https://nyaa.si/?page=rss'
 export const MAGNET_REDIRECT = 'https://magnet.flacial.dev/api/link/'
+export const MAGNET_ERROR = 'Oops, our apps is faster than their server. We could not get the magnet'

--- a/src/utils/createCaption.util.ts
+++ b/src/utils/createCaption.util.ts
@@ -1,6 +1,6 @@
 import { pipe } from "fp-ts/lib/function"
 import { FeedItem } from "../@types/data.type"
-import { MAGNET_REDIRECT } from "../constants"
+import { MAGNET_ERROR, MAGNET_REDIRECT } from "../constants"
 import { formatTitle } from "./formatTitle.util"
 import { getItemHTML, getMagnet } from "./getData.util"
 import { getPoster } from "./poster.util"
@@ -24,10 +24,8 @@ export const createCaption = async (item: FeedItem) => {
         getItemHTML,
         getMagnet
     )
-    const magnetBase64 = Buffer.from(magnet).toString('base64')
-    const magnetCaption = magnet ?
-        `${strongHTML('Magnet:')} ${linkHTML(`${MAGNET_REDIRECT}${magnetBase64}`)}`
-        : ''
+    const magnetBase64 = magnet && Buffer.from(magnet).toString('base64')
+    const magnetCaption = `${strongHTML('Magnet:')} ${magnet ? linkHTML(`${MAGNET_REDIRECT}${magnetBase64}`) : MAGNET_ERROR}`
     
     const size = item?.size
     const sizeCaption = size ? `${strongHTML('Size:')} ${codeHTML(size)}` : ''

--- a/src/utils/getData.util.ts
+++ b/src/utils/getData.util.ts
@@ -4,10 +4,16 @@ import axios from 'axios'
 
 export const getItemHTML = async (item: FeedItem | Promise<FeedItem>): Promise<{ data: string }> => axios.get((await item).guid)
 
-export const getMagnet = async (html: Promise<{ data: string }>) => {
-    const HTML = await html
-    const { window: { document } } = new JSDOM(HTML.data);
-    const magnet = document.querySelector('.card-footer-item') as HTMLAnchorElement
+export const getMagnet = async (html: Promise<{ data: string }>, errorTimes = 0) => {
+    try {
+        const HTML = await html
+        const { window: { document } } = new JSDOM(HTML.data)
+        const magnet = document.querySelector('.card-footer-item') as HTMLAnchorElement
 
-    return magnet?.href
+        return magnet?.href
+    } catch (err) {
+        if (errorTimes >= 10) return null
+
+        await getMagnet(html, errorTimes + 1)
+    }
 }


### PR DESCRIPTION
Closes #9 

This PR will update the [`getMagnet`](https://github.com/flacial/nyaasi-bot-tg/blob/caf149f18261027fa262ff4bb3b2c060ae524773/src/utils/getData.util.ts#L7) to try 10 times to get the magnet before returning `null` or throw an error as before.

*Why retry 10 times:* no specific reason, it felt like the sweet spot. 